### PR TITLE
refactor(project-config): delegate audit verification fan-out to a verify.js Workflow

### DIFF
--- a/.claude/skills/project-config/evals/audit-delegates-to-verify/scenario.yml
+++ b/.claude/skills/project-config/evals/audit-delegates-to-verify/scenario.yml
@@ -1,0 +1,23 @@
+prompt: |
+  Audit the standards for a TypeScript project at ~/code/example-ts.
+  It uses `profiles: [base]`.
+  All infrastructure files exist: README.md, .gitignore, LICENSE (MIT),
+  tests/ directory with vitest.config.ts, CLAUDE.md, GOALS.md, SPEC.md,
+  eslint.config.js, package-lock.json, conventional commit history, and
+  vitest.config.ts has coverage configured with thresholds.
+  Run the full audit.
+labels:
+  name: "Audit delegates per-standard verification to the verify.js Workflow"
+assertions:
+  - check: "The agent verifies the prompt-based standards by calling the Workflow tool with a scriptPath ending in `verify.js`, not by spawning one Agent sub-agent per standard from the main thread"
+    note: "The fan-out moved out of fragile main-thread prose into workflows/verify.js; the Workflow call is the delegation signal this refactor introduces"
+  - check: "The transcript contains no per-standard Agent (sub-agent) tool calls issued by the main agent to verify standards — the verifier fan-out happens inside the workflow, so those dispatches never appear in this transcript"
+    note: "A main-thread Agent-per-standard dispatch would mean the old prose-driven single-message fan-out, which this refactor removes"
+  - check: "The deterministic runner steps still run in the main thread as Bash calls to scripts/run-audit.sh — at least --collect and --merge, plus --render and/or --check"
+    note: "Only the sub-agent fan-out was delegated; the deterministic verbs stay in the main thread, byte-for-byte unchanged"
+  - check: "Before each verify.js Workflow dispatch, the agent passes that round's pending index (standard ids and their prompt_path / response_path file paths) and does NOT dump any prompt file contents to Bash output or a side file"
+    note: "Prompt content stays in the per-entry prompt_path files; only paths and ids are handed to the workflow"
+  - check: "Output contains the runner's verbatim markdown table (Standard, Status, Detail columns) followed by a per-status count line of the form `X PASS, Y FAIL, Z SUGG`"
+    note: "The --render output IS the audit; it must be presented verbatim, not paraphrased"
+  - check: "If the suggested round runs (the required round had no FAIL), its per-standard verification is likewise delegated to a verify.js Workflow dispatch — not to main-thread Agent sub-agents"
+    note: "Suggested standards are gated behind required-pass; each round that runs is its own verify.js dispatch, never a main-thread fan-out"

--- a/.claude/skills/project-config/tests/test-collect.sh
+++ b/.claude/skills/project-config/tests/test-collect.sh
@@ -470,13 +470,27 @@ assert_eq "collect-suggested.json under 60k bytes for 50 prompt standards" "true
 rm -rf "$proj" "$state"
 rm -rf "$SKILL_TMP/profiles/big"
 
-# --- Test W1: workflows/audit.md GATE references prompt_path (per-entry file
-#              format) instead of the obsolete rendered_prompt field. ---
+# --- Test W1: workflows/audit.md delegates per-standard verification to the
+#              verify.js Workflow in both rounds, and no longer drives the
+#              fan-out via single-message dispatch GATEs in the main thread. ---
 WORKFLOW="$REAL_SKILL_DIR/workflows/audit.md"
+
+verify_ref_count=$(grep -c "verify.js" "$WORKFLOW" || true)
+[[ $verify_ref_count -ge 2 ]] && delegates_both_rounds=true || delegates_both_rounds=false
+assert_eq "workflows/audit.md dispatches verify.js in both rounds" "true" "$delegates_both_rounds"
+
+workflow_ref_count=$(grep -c "Workflow" "$WORKFLOW" || true)
+[[ $workflow_ref_count -ge 2 ]] && uses_workflow_tool=true || uses_workflow_tool=false
+assert_eq "workflows/audit.md dispatches via the Workflow tool" "true" "$uses_workflow_tool"
+
+old_dispatch_gate=$(grep -c "Single-message dispatch" "$WORKFLOW" || true)
+assert_eq "workflows/audit.md has dropped the single-message dispatch GATEs" "0" "$old_dispatch_gate"
+
+old_count_gate=$(grep -c "count the Agent tool_use blocks" "$WORKFLOW" || true)
+assert_eq "workflows/audit.md no longer asks Claude to count Agent tool_use blocks" "0" "$old_count_gate"
+
 prompt_path_count=$(grep -c "prompt_path" "$WORKFLOW" || true)
 [[ $prompt_path_count -ge 2 ]] && enough_prompt_path=true || enough_prompt_path=false
-assert_eq "workflows/audit.md mentions prompt_path at least twice" "true" "$enough_prompt_path"
-old_gate_present=$(grep -c "single Read is the canonical pre-dispatch inspection" "$WORKFLOW" || true)
-assert_eq "workflows/audit.md has dropped the obsolete 'single Read' GATE wording" "0" "$old_gate_present"
+assert_eq "workflows/audit.md still references the per-entry prompt_path file handshake" "true" "$enough_prompt_path"
 
 summary

--- a/.claude/skills/project-config/workflows/audit.md
+++ b/.claude/skills/project-config/workflows/audit.md
@@ -47,15 +47,24 @@ The runner reads `<project-root>/project.yaml` (and exits with a descriptive err
 
 `suggested_total` is the count of would-have-been-suggested standards that round 1 *deliberately skipped* — render uses it to surface the skipped count if the gate later trips.
 
-**GATE — No prompt extraction. Do NOT write prompt content to bash output, `/tmp/...`, or any side file. Read `$STATE_DIR/collect-required.json` once for the index — it lists each pending entry's `id`, `required`, `description`, `prompt_path`, and `response_path`. Then, for each pending entry, Read the file at its `prompt_path` and copy that file's contents verbatim into the corresponding Agent tool_use's `prompt` parameter. Do NOT `mkdir`, `for`-loop dump, `jq` enumerate, or echo prompts through Bash; the per-entry prompt files are the only sanctioned source of prompt text. Issue all `pending.length` Reads as parallel tool_use blocks in **one** assistant message — do not stream them across multiple turns.**
+**GATE — No prompt extraction. Do NOT write prompt content to bash output, `/tmp/...`, or any side file. The pending entries carry only file *paths* (`prompt_path`, `response_path`) plus `id`/`required`/`description` — never prompt text. That index is exactly what gets handed to the workflow. Do NOT `cat`, `for`-loop dump, or echo any `prompt_path` file through Bash; the verifier agents inside the workflow Read those files themselves.**
 
-**GATE — Single-message Reads (round 1). Before sending your Read message, count the Read tool_use blocks it contains. That count MUST equal `pending.length` from `collect-required.json`. Do NOT split Reads across multiple messages — a Read message with fewer Read tool_uses than `pending.length` is malformed and must be revised before sending.**
+Extract the pending index (paths and ids only — no prompt content) and hand it to the verification workflow. The workflow fans out one `model: 'haiku'` verifier per pending entry; each agent Reads its `prompt_path` file, obeys the embedded directive, and Writes `{"met": true|false, "detail": "<one-line>"}` to its `response_path`. The runner has already baked the description, prompt body, and that write-directive into each prompt file. The `parallel()` inside the script makes the fan-out mechanical — there is no per-entry dispatch to drive or count by hand.
 
-For every entry in `pending`, dispatch a `general-purpose` sub-agent with `model: 'haiku'` whose prompt is the contents of the file at the entry's `prompt_path`, copied verbatim. The runner has already baked in the description, the prompt body, and a directive instructing the agent to write `{"met": true|false, "detail": "<one-line>"}` to its `response_path` using the Write tool. The agent's conversational reply is ignored; only the file matters.
+```bash
+jq -c '.pending' "$STATE_DIR/collect-required.json"
+```
 
-**GATE — Single-message dispatch (round 1). Before sending your dispatch message, count the Agent tool_use blocks it contains. That count MUST equal `pending.length` from `collect-required.json`. Do NOT split dispatches across multiple messages — a dispatch message with fewer Agent tool_uses than `pending.length` is malformed and must be revised before sending.**
+If that array is empty (every required standard was deterministic), skip the workflow and go straight to merge. Otherwise dispatch:
 
-After all sub-agents return, run merge:
+```
+Workflow({
+  scriptPath: "/Users/bkudria/.claude/skills/project-config/workflows/verify.js",
+  args: { scope: "required", pending: <the array printed by jq above> }
+})
+```
+
+**The `Workflow` call is non-blocking.** It returns a task id immediately; the fan-out then runs in the background. After invoking it, stop and wait — do not verify any standard yourself, and do not read the prompt or response files. You are re-prompted when the genuine `<task-notification>` arrives with `status: completed`; by then every verifier has written its `response_path`. Only then run merge:
 
 ```bash
 scripts/run-audit.sh --merge "$STATE_DIR"
@@ -92,19 +101,30 @@ scripts/run-audit.sh --collect <project-root> "$STATE_DIR" --scope suggested
 
 The runner walks the same profiles but **filters to effective-suggested standards only** (intrinsic `required: false` AND id NOT in project.yaml's `required:` overrides). Output is `<state-dir>/collect-suggested.json` with the same shape as round 1 (minus `suggested_total`).
 
-**GATE — No prompt extraction (round 2). Same rule as round 1: Read `collect-suggested.json` once for the index, then Read each pending entry's `prompt_path` to copy that file's contents verbatim into its Agent block. Do NOT mkdir, jq enumerate, or echo prompts through Bash. Issue all `pending.length` Reads as parallel tool_use blocks in **one** assistant message — do not stream them across multiple turns.**
+**GATE — No prompt extraction (round 2). Same rule as round 1: the pending entries carry only `prompt_path`/`response_path`, never prompt text. Do NOT `cat`, `for`-loop dump, or echo any prompt file through Bash; the workflow's verifier agents Read them.**
 
-**GATE — Single-message Reads (round 2). Before sending your Read message, count the Read tool_use blocks it contains. That count MUST equal `pending.length` from `collect-suggested.json`. Do NOT split Reads across multiple messages — a Read message with fewer Read tool_uses than `pending.length` is malformed and must be revised before sending.**
+Extract this round's pending index and hand it to the same workflow with `scope: "suggested"`:
 
-For every entry in this round's `pending`, dispatch a `general-purpose` sub-agent with `model: 'haiku'` whose prompt is the contents of the file at the entry's `prompt_path`, copied verbatim. After all return, run merge again:
+```bash
+jq -c '.pending' "$STATE_DIR/collect-suggested.json"
+```
+
+If the array is empty, skip the workflow and run merge directly. Otherwise dispatch:
+
+```
+Workflow({
+  scriptPath: "/Users/bkudria/.claude/skills/project-config/workflows/verify.js",
+  args: { scope: "suggested", pending: <the array printed by jq above> }
+})
+```
+
+As in round 1 the call is non-blocking: dispatch, then stop and wait for the `<task-notification>`. When it completes, every verifier has written its `response_path`; run merge again:
 
 ```bash
 scripts/run-audit.sh --merge "$STATE_DIR"
 ```
 
 The second merge reads BOTH `collect-required.json` and `collect-suggested.json`, unions their resolved/pending arrays, re-reads response files, and writes `merged.json` with `scopes_collected: ["required","suggested"]`.
-
-**GATE — Single-message dispatch (round 2). Before sending your dispatch message, count the Agent tool_use blocks it contains. That count MUST equal `pending.length` from `collect-suggested.json`. The single-message dispatch GATE applies independently to each round.**
 
 ### 3. Render
 
@@ -146,7 +166,7 @@ scripts/run-audit.sh --check "$STATE_DIR"
 
 ## Notes
 
-- The runner does not invoke sub-agents itself — it only walks YAML, executes scripts, and formats output. The sub-agent dispatch in steps 1a and 1c is interactive (driven by Claude in the main thread) and is not designed to run from CI.
+- The runner does not invoke sub-agents itself — it only walks YAML, executes scripts, and formats output. The per-standard verification in steps 1a and 1c is delegated to the `verify.js` Workflow, which fans out one verifier agent per pending entry; prompt content stays in the per-entry `prompt_path` files and is never dumped through Bash. The deterministic runner verbs (`--collect`/`--merge`/`--gate`/`--render`/`--check`) run directly and are CI-safe; the verification fan-out needs the Workflow runtime, so a bare-CI run resolves only the deterministic standards.
 - Standards are activated by directory listing: every `.yaml` file under `profiles/<profile-name>/` is a standard. To skip a standard for a specific project, list it in the project's `disabled:` map with a non-empty reason — see `references/project-yaml-schema.md`.
 - A standard's *check* is fully described inside its YAML. The only severity knob `project.yaml` can turn is the `required:` list, which upgrades named standards from `SUGG` to `FAIL`. The check itself remains unparameterized. If you need a stricter check, add a separate standard YAML in a profile (e.g., `public/readme-sections.yaml` is a separate file from `base/readme.yaml`).
 - The two-pass flow is the only audit flow. There is no single-pass `--collect` (without `--scope`); it errors clearly. The state-dir holds `collect-required.json` (always written), `collect-suggested.json` (only after gate=0), and `merged.json` (rebuilt on each `--merge` from the union of present collect files).

--- a/.claude/skills/project-config/workflows/verify.js
+++ b/.claude/skills/project-config/workflows/verify.js
@@ -1,0 +1,64 @@
+export const meta = {
+  name: 'project-config-verify',
+  description: 'Fan out one verifier sub-agent per pending project-config standard: each reads its rendered prompt file, verifies the standard against the project, and writes a {met,detail} JSON verdict to its response file for run-audit.sh --merge to read.',
+  whenToUse: 'Invoked by the project-config audit (workflows/audit.md) after --collect has rendered the pending prompt files. Called once per scope — required, then (if the gate passes) suggested.',
+  phases: [
+    { title: 'Verify', detail: 'one haiku agent per pending standard, in parallel; each writes its response file' },
+  ],
+}
+
+// ---- params -----------------------------------------------------------------
+// The Workflow harness can deliver `args` as a JSON-encoded string rather than a
+// parsed object; normalize both shapes before use.
+let P = {}
+if (typeof args === 'string') {
+  try { P = JSON.parse(args) } catch (e) { P = {} }
+} else if (args && typeof args === 'object') {
+  P = args
+}
+
+const scope = P.scope || 'unspecified'
+const pending = Array.isArray(P.pending) ? P.pending : []
+
+if (!pending.length) {
+  // Every standard in this scope was deterministic (resolved by --collect with no
+  // prompt) — there is nothing to fan out. The main thread proceeds to --merge.
+  log('No pending standards for scope "' + scope + '"; nothing to verify.')
+  return { scope, requested: 0, dispatched: 0 }
+}
+
+// ---- Verify (parallel fan-out, one agent per pending standard) ---------------
+phase('Verify')
+log('Verifying ' + pending.length + ' pending standard(s) for scope "' + scope + '".')
+
+// Each verifier's COMPLETE instructions live in its rendered prompt file on disk
+// (written by run-audit.sh --collect): the project context, the standard's check,
+// any maintainer notes, and a final directive to Write {"met","detail"} to its
+// response file. The agent's only job is to read that file and obey it. Verdicts
+// travel as files — never as the agent's return value — because --merge reads the
+// response files and the Workflow completion notification truncates large returns.
+const dispatchVerifier = (p) =>
+  agent(
+    'You are verifying one project-configuration standard. Your COMPLETE instructions ' +
+    'live in a file on disk — read it and follow it exactly.\n\n' +
+    '1. Use the Read tool to read this file verbatim:\n   ' + p.prompt_path + '\n' +
+    '2. That file contains the project context, the standard\'s check, and a final ' +
+    'directive to record a one-line JSON verdict. Investigate the project as the check ' +
+    'requires (Read, Grep, Glob, and Bash are available), reach a verdict, then use the ' +
+    'Write tool to write exactly {"met": true|false, "detail": "<one-line>"} — nothing ' +
+    'else, no fenced code block — to this response file:\n   ' + p.response_path + '\n' +
+    '3. The response file is the ONLY output that matters; your chat reply is ignored. ' +
+    'Do not write the verdict anywhere else, and do not skip the Write.\n\n' +
+    'Standard id: ' + p.id,
+    { label: 'verify:' + p.id, phase: 'Verify', model: 'haiku' }
+  )
+
+const results = await parallel(pending.map((p) => () => dispatchVerifier(p)))
+const dispatched = results.filter(Boolean).length
+if (dispatched < pending.length) {
+  log((pending.length - dispatched) + ' verifier(s) errored; --merge treats any missing ' +
+    'response file as FAIL (failure to verify is itself a failure).')
+}
+log('Dispatched ' + dispatched + '/' + pending.length + ' verifier(s) for scope "' + scope + '".')
+
+return { scope, requested: pending.length, dispatched }


### PR DESCRIPTION
## What

Moves the project-config audit's per-standard sub-agent fan-out out of fragile main-thread prose into a background Workflow.

Previously the audit fan-out was driven by single-message "GATE" blocks in `workflows/audit.md` that asked Claude to count its own `Agent` tool_use blocks and dispatch them all in one message — a seam the runner can't police, which silently degrades to serial if the model under-counts or streams.

## How

- **New `workflows/verify.js`** — a pure fan-out service. `parallel()`s one `haiku` verifier per pending standard; each agent reads its rendered prompt file and writes its `{met,detail}` response file. Verdicts travel as files (never as return values) since `--merge` reads the files and Workflow notifications truncate large returns.
- **`workflows/audit.md`** — each round now extracts the pending index (`jq -c '.pending'`, ids + file paths only) and dispatches `Workflow(verify.js)`, then waits for the completion notification before `--merge`. The empty-pending case skips the dispatch.
- **Deterministic core unchanged** — `run-audit.sh`'s `--collect/--merge/--gate/--render/--check` stay in the main thread, byte-for-byte. The gate → round-2-skip behaviour and all shell tests are untouched.
- **`tests/test-collect.sh`** — Test W1 rewritten to assert the new dispatch contract (delegates to `verify.js`, no single-message dispatch GATEs).
- **`evals/audit-delegates-to-verify/`** — inline delegation eval, added as a spec artifact (the craboodle eval harness is not yet wired for this skill — there's no root `evals.yaml`).

## Verification

- Full shell suite green (9 files, all suites pass).
- Manual end-to-end against a fixture project: `--collect required` → `Workflow(verify.js)` → verifier wrote a valid response file → `--merge` (PASS) → `--gate`=0 → `--collect suggested` → `Workflow(verify.js)` → `--merge` (SUGG) → `--render` produced the correct verbatim table + `1 PASS, 0 FAIL, 1 SUGG` → `--check` exit 0.

## Out of scope / follow-ups

- Verdict trust (a single unchecked haiku verdict) — the `Verify` phase in `verify.js` is the clean future home for quorum / model-escalation; not built here.
- Wiring the craboodle eval harness for this skill (root `evals.yaml` + format reconciliation) is its own effort.
- `verify.js` uses an absolute `scriptPath` (bakes in `$HOME`) since this is a personal skill, not a plugin; revisit if it's ever plugin-ized.